### PR TITLE
input-group support

### DIFF
--- a/angular-bootstrap-datetimepicker-directive.js
+++ b/angular-bootstrap-datetimepicker-directive.js
@@ -37,11 +37,9 @@ angular
           var passed_in_options = $scope.$eval($attrs.datetimepickerOptions);
           var options = jQuery.extend({}, default_options, passed_in_options);
 
-          if ($element.parent().hasClass('input-group')) {
-            $element = $element.parent()
-          }
+          var datePickerElement = $element.parent().hasClass('input-group') ? $element.parent() : $element;
 
-          $element
+          datePickerElement
             .on('dp.change', function (e) {
               if (ngModelCtrl) {
                 $timeout(function () {
@@ -58,7 +56,7 @@ angular
               date = ngModelCtrl.$viewValue;
             }
 
-            $element
+            datePickerElement
               .data('DateTimePicker')
               .date(date);
           }

--- a/angular-bootstrap-datetimepicker-directive.js
+++ b/angular-bootstrap-datetimepicker-directive.js
@@ -37,6 +37,10 @@ angular
           var passed_in_options = $scope.$eval($attrs.datetimepickerOptions);
           var options = jQuery.extend({}, default_options, passed_in_options);
 
+          if ($element.parent().hasClass('input-group')) {
+            $element = $element.parent()
+          }
+
           $element
             .on('dp.change', function (e) {
               if (ngModelCtrl) {


### PR DESCRIPTION
If the input is placed inside input-group, the datetimepicker is assigned to it's parent
